### PR TITLE
Updating Websocket Protocol as per assetPrefix

### DIFF
--- a/packages/next/client/dev/error-overlay/websocket.ts
+++ b/packages/next/client/dev/error-overlay/websocket.ts
@@ -32,7 +32,7 @@ export function connectHMR(options: {
   function init() {
     if (source) source.close()
     const { hostname, port } = location
-    const protocol = location.protocol === 'http:' ? 'ws' : 'wss'
+    let protocol = location.protocol === 'http:' ? 'ws' : 'wss'
     const assetPrefix = options.assetPrefix.replace(/^\/+/, '')
 
     let url = `${protocol}://${hostname}:${port}${
@@ -40,6 +40,7 @@ export function connectHMR(options: {
     }`
 
     if (assetPrefix.startsWith('http')) {
+      protocol = assetPrefix.split('://')[0] === 'http' ? 'ws' : 'wss';
       url = `${protocol}://${assetPrefix.split('://')[1]}`
     }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Your contribution is much appreciated.
In order to make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change that you're making:
-->
Problem:
When the browser location protocol is `https`, and the assetPrefix (link to CDN) corresponds to an `http` protocol (like `http://localhost:3000` ),  the websocket protocol is still determined only by browser's location, and becomes `wss://`. This will lead to an incorrect websocket protocol & URL (`wss://localhost:3000/`, for eg.)

Changes:

This PR updates the Websocket protocol as per the assetPrefix.
## Bug

- [ ] Related issues linked using fixes #31139
- [ ] Integration tests added
- [ ] Errors have helpful link attached, see `contributing.md`
